### PR TITLE
Improved pagination ui

### DIFF
--- a/app/src/main/java/zechs/drive/stream/ui/files/adapter/FilesAdapter.kt
+++ b/app/src/main/java/zechs/drive/stream/ui/files/adapter/FilesAdapter.kt
@@ -3,28 +3,53 @@ package zechs.drive.stream.ui.files.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
+import zechs.drive.stream.R
 import zechs.drive.stream.data.model.DriveFile
 import zechs.drive.stream.databinding.ItemDriveFileBinding
+import zechs.drive.stream.databinding.ItemLoadingBinding
 
 class FilesAdapter(
     val onClickListener: (DriveFile) -> Unit
-) : ListAdapter<DriveFile, FilesViewHolder>(FilesItemDiffCallback()) {
+) : ListAdapter<FilesDataModel, FilesViewHolder>(FilesItemDiffCallback()) {
 
     override fun onCreateViewHolder(
         parent: ViewGroup, viewType: Int
-    ) = FilesViewHolder(
-        itemBinding = ItemDriveFileBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent, false
-        ),
-        filesAdapter = this
-    )
+    ): FilesViewHolder {
 
-    override fun onBindViewHolder(
-        holder: FilesViewHolder,
-        position: Int
-    ) {
-        holder.bind(getItem(position))
+        val filesViewHolder = FilesViewHolder.DriveFileViewHolder(
+            itemBinding = ItemDriveFileBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent, false
+            ),
+            filesAdapter = this
+        )
+
+        val loadingViewHolder = FilesViewHolder.LoadingViewHolder(
+            itemBinding = ItemLoadingBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent, false
+            )
+        )
+
+        return when (viewType) {
+            R.layout.item_loading -> loadingViewHolder
+            R.layout.item_drive_file -> filesViewHolder
+            else -> throw IllegalArgumentException("Invalid view type")
+        }
     }
 
+    override fun onBindViewHolder(holder: FilesViewHolder, position: Int) {
+        val item = getItem(position)
+        when (holder) {
+            is FilesViewHolder.LoadingViewHolder -> item as FilesDataModel.Loading
+            is FilesViewHolder.DriveFileViewHolder -> holder.bind(item as FilesDataModel.File)
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when (getItem(position)) {
+            is FilesDataModel.Loading -> R.layout.item_loading
+            is FilesDataModel.File -> R.layout.item_drive_file
+        }
+    }
 }

--- a/app/src/main/java/zechs/drive/stream/ui/files/adapter/FilesDataModel.kt
+++ b/app/src/main/java/zechs/drive/stream/ui/files/adapter/FilesDataModel.kt
@@ -1,0 +1,15 @@
+package zechs.drive.stream.ui.files.adapter
+
+import androidx.annotation.Keep
+import zechs.drive.stream.data.model.DriveFile
+
+sealed class FilesDataModel {
+
+    @Keep
+    data class File(
+        val driveFile: DriveFile
+    ) : FilesDataModel()
+
+    object Loading : FilesDataModel()
+
+}

--- a/app/src/main/java/zechs/drive/stream/ui/files/adapter/FilesItemDiffCallback.kt
+++ b/app/src/main/java/zechs/drive/stream/ui/files/adapter/FilesItemDiffCallback.kt
@@ -1,16 +1,28 @@
 package zechs.drive.stream.ui.files.adapter
 
 import androidx.recyclerview.widget.DiffUtil
-import zechs.drive.stream.data.model.DriveFile
 
-class FilesItemDiffCallback : DiffUtil.ItemCallback<DriveFile>() {
+class FilesItemDiffCallback : DiffUtil.ItemCallback<FilesDataModel>() {
+
 
     override fun areItemsTheSame(
-        oldItem: DriveFile, newItem: DriveFile
-    ) = oldItem.id == newItem.id
+        oldItem: FilesDataModel,
+        newItem: FilesDataModel
+    ): Boolean = when {
+
+        oldItem is FilesDataModel.Loading && newItem is FilesDataModel.Loading
+                && oldItem == newItem
+        -> true
+
+        oldItem is FilesDataModel.File && newItem is FilesDataModel.File &&
+                oldItem.driveFile.id == newItem.driveFile.id
+        -> true
+
+        else -> false
+    }
 
     override fun areContentsTheSame(
-        oldItem: DriveFile, newItem: DriveFile
+        oldItem: FilesDataModel, newItem: FilesDataModel
     ) = oldItem == newItem
 
 }

--- a/app/src/main/java/zechs/drive/stream/ui/files/adapter/FilesViewHolder.kt
+++ b/app/src/main/java/zechs/drive/stream/ui/files/adapter/FilesViewHolder.kt
@@ -2,44 +2,57 @@ package zechs.drive.stream.ui.files.adapter
 
 import androidx.core.view.isGone
 import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
 import com.bumptech.glide.request.RequestOptions
 import zechs.drive.stream.R
-import zechs.drive.stream.data.model.DriveFile
 import zechs.drive.stream.databinding.ItemDriveFileBinding
+import zechs.drive.stream.databinding.ItemLoadingBinding
 import zechs.drive.stream.utils.GlideApp
 
-class FilesViewHolder(
-    private val itemBinding: ItemDriveFileBinding,
-    val filesAdapter: FilesAdapter
-) : RecyclerView.ViewHolder(itemBinding.root) {
+sealed class FilesViewHolder(
+    binding: ViewBinding
+) : RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(item: DriveFile) {
-        itemBinding.apply {
 
-            val iconLink = item.iconLink128 ?: R.drawable.ic_my_drive_24
+    class DriveFileViewHolder(
+        private val itemBinding: ItemDriveFileBinding,
+        val filesAdapter: FilesAdapter
+    ) : FilesViewHolder(itemBinding) {
 
-            GlideApp.with(ivFileType)
-                .load(iconLink)
-                .apply(RequestOptions().override(48, 48))
-                .into(ivFileType)
+        fun bind(file: FilesDataModel.File) {
+            val item = file.driveFile
+            itemBinding.apply {
 
-            tvFileName.text = item.name
+                val iconLink = item.iconLink128 ?: R.drawable.ic_my_drive_24
 
-            val tvFileSizeTAG = "tvFileSize"
+                GlideApp.with(ivFileType)
+                    .load(iconLink)
+                    .apply(RequestOptions().override(48, 48))
+                    .into(ivFileType)
 
-            tvFileSize.apply {
-                tag = if (item.size == null) {
-                    tvFileSizeTAG
-                } else null
+                tvFileName.text = item.name
 
-                isGone = tag == tvFileSizeTAG
-                text = item.humanSize
+                val tvFileSizeTAG = "tvFileSize"
+
+                tvFileSize.apply {
+                    tag = if (item.size == null) {
+                        tvFileSizeTAG
+                    } else null
+
+                    isGone = tag == tvFileSizeTAG
+                    text = item.humanSize
+                }
+
+                root.setOnClickListener {
+                    filesAdapter.onClickListener.invoke(item)
+                }
+
             }
-
-            root.setOnClickListener {
-                filesAdapter.onClickListener.invoke(item)
-            }
-
         }
     }
+
+    class LoadingViewHolder(
+        itemBinding: ItemLoadingBinding
+    ) : FilesViewHolder(itemBinding)
+
 }

--- a/app/src/main/res/layout/fragment_files.xml
+++ b/app/src/main/res/layout/fragment_files.xml
@@ -27,7 +27,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:clipToPadding="false"
-        android:paddingBottom="72dp"
         app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
 
     <ProgressBar
@@ -37,16 +36,6 @@
         android:layout_gravity="center"
         android:elevation="24dp"
         android:visibility="invisible"
-        tools:visibility="visible" />
-
-    <ProgressBar
-        android:id="@+id/pagingLoading"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|center_horizontal"
-        android:layout_marginBottom="8dp"
-        android:elevation="24dp"
-        android:visibility="gone"
         tools:visibility="visible" />
 
     <include

--- a/app/src/main/res/layout/item_loading.xml
+++ b/app/src/main/res/layout/item_loading.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ProgressBar
+        android:id="@+id/loading"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:padding="16dp" />
+
+</FrameLayout>


### PR DESCRIPTION
Instead of showing and hiding a `ProgressBar` in main fragment's layout, adding a `item` with progress bar at end of the list if response is not at last page and simply not adding it if we are at last page. No extra logic required to show/hide `ProgressBar` for pagination