### PR TITLE
Fix: Unable to authenticate

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,9 +76,6 @@ dependencies {
     def moshi_version = "1.13.0"
     def retrofit_version = "2.9.0"
 
-    // Custom Tabs
-    implementation "androidx.browser:browser:1.4.0"
-
     // Gson
     implementation "com.google.code.gson:gson:2.9.0"
 

--- a/app/src/main/java/zechs/drive/stream/ui/code/DialogCode.kt
+++ b/app/src/main/java/zechs/drive/stream/ui/code/DialogCode.kt
@@ -32,7 +32,7 @@ class DialogCode(
             val authCode = codeText.editText!!.text.toString()
 
             if (authCode.isEmpty()) {
-                showToast(context.getString(R.string.please_enter_auth_code))
+                showToast(context.getString(R.string.please_enter_auth_url))
             } else {
                 onSubmitClickListener.invoke(authCode)
             }

--- a/app/src/main/java/zechs/drive/stream/ui/signin/SignInFragment.kt
+++ b/app/src/main/java/zechs/drive/stream/ui/signin/SignInFragment.kt
@@ -1,5 +1,6 @@
 package zechs.drive.stream.ui.signin
 
+import android.content.Intent
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.net.Uri
@@ -9,7 +10,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
-import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
@@ -53,9 +53,9 @@ class SignInFragment : BaseFragment() {
         _binding = FragmentSignInBinding.bind(view)
 
         binding.signInText.setOnClickListener {
-            CustomTabsIntent.Builder().build().also {
-                it.launchUrl(requireContext(), Uri.parse(AUTH_URL))
-            }
+            Intent().setAction(Intent.ACTION_VIEW)
+                .setData(Uri.parse(AUTH_URL))
+                .also { startActivity(it) }
         }
 
         binding.enterCode.setOnClickListener {

--- a/app/src/main/java/zechs/drive/stream/ui/signin/SignInFragment.kt
+++ b/app/src/main/java/zechs/drive/stream/ui/signin/SignInFragment.kt
@@ -13,6 +13,7 @@ import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import zechs.drive.stream.R
 import zechs.drive.stream.databinding.FragmentSignInBinding
@@ -59,7 +60,13 @@ class SignInFragment : BaseFragment() {
         }
 
         binding.enterCode.setOnClickListener {
-            showCodeDialog()
+            MaterialAlertDialogBuilder(requireContext())
+                .setTitle("Please note")
+                .setMessage(getString(R.string.important_note_message))
+                .setPositiveButton("Continue") { dialog, _ ->
+                    dialog.dismiss()
+                    showCodeDialog()
+                }.show()
         }
 
         loginObserver()

--- a/app/src/main/java/zechs/drive/stream/ui/signin/SignInFragment.kt
+++ b/app/src/main/java/zechs/drive/stream/ui/signin/SignInFragment.kt
@@ -90,8 +90,8 @@ class SignInFragment : BaseFragment() {
         if (_codeDialog == null) {
             _codeDialog = DialogCode(
                 context = requireContext(),
-                onSubmitClickListener = { code ->
-                    viewModel.requestRefreshToken(code)
+                onSubmitClickListener = { codeUri ->
+                    viewModel.requestRefreshToken(codeUri)
                     codeDialog.dismiss()
                 }
             )

--- a/app/src/main/java/zechs/drive/stream/ui/signin/SignInViewModel.kt
+++ b/app/src/main/java/zechs/drive/stream/ui/signin/SignInViewModel.kt
@@ -1,5 +1,6 @@
 package zechs.drive.stream.ui.signin
 
+import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -22,11 +23,16 @@ class SignInViewModel @Inject constructor(
         get() = _loginStatus
 
     fun requestRefreshToken(
-        authCode: String
+        authCodeUri: String
     ) = viewModelScope.launch {
         _loginStatus.postValue(Resource.Loading())
-        val response = driveRepository.get().fetchRefreshToken(authCode)
-        _loginStatus.postValue(response)
+        val authCode = Uri.parse(authCodeUri).getQueryParameter("code")
+        if (authCode == null) {
+            _loginStatus.postValue(Resource.Error("Authorization code not found, please check url"))
+        } else {
+            val response = driveRepository.get().fetchRefreshToken(authCode)
+            _loginStatus.postValue(response)
+        }
     }
 
 }

--- a/app/src/main/java/zechs/drive/stream/utils/util/Constants.kt
+++ b/app/src/main/java/zechs/drive/stream/utils/util/Constants.kt
@@ -5,14 +5,14 @@ import zechs.drive.stream.BuildConfig
 class Constants {
     companion object {
         const val GITHUB_API = "https://api.github.com"
-        const val GOOGLE_API = "https://www.googleapis.com/"
+        const val GOOGLE_API = "https://www.googleapis.com"
         const val DRIVE_API = "${GOOGLE_API}/drive/v3"
         const val GOOGLE_ACCOUNTS_URL = "https://accounts.google.com"
 
         const val CLIENT_ID = BuildConfig.CLIENT_ID
         const val CLIENT_SECRET = BuildConfig.CLIENT_SECRET
 
-        const val REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
+        const val REDIRECT_URI = "http://127.0.0.1:53682"
         private const val SCOPES = "https://www.googleapis.com/auth/drive"
 
         const val AUTH_URL = "${GOOGLE_ACCOUNTS_URL}/o/oauth2/auth?" +

--- a/app/src/main/res/layout/dialog_code.xml
+++ b/app/src/main/res/layout/dialog_code.xml
@@ -27,7 +27,7 @@
             android:clickable="false"
             android:focusable="false"
             android:fontFamily="@font/roboto_medium"
-            android:text="@string/authorization_code"
+            android:text="@string/authorization_url"
             android:textColor="@color/textColor"
             android:textSize="21sp"
             app:layout_constraintEnd_toEndOf="parent"
@@ -61,7 +61,7 @@
             android:layout_marginStart="24dp"
             android:layout_marginTop="16dp"
             android:layout_marginEnd="24dp"
-            android:hint="@string/authorization_code"
+            android:hint="@string/authorization_url_hint"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/tvExample">

--- a/app/src/main/res/layout/dialog_code.xml
+++ b/app/src/main/res/layout/dialog_code.xml
@@ -35,6 +35,23 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tvExample"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="24dp"
+            android:clickable="false"
+            android:ellipsize="end"
+            android:focusable="false"
+            android:maxLines="2"
+            android:text="@string/authorization_code_example"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"
+            android:textColor="@color/textColor_74"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_title" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tf_code"
@@ -47,7 +64,7 @@
             android:hint="@string/authorization_code"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tv_title">
+            app:layout_constraintTop_toBottomOf="@+id/tvExample">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,5 @@
     <string name="please_enter_auth_code">Please enter authorization code</string>
     <string name="play_using">Play using</string>
     <string name="new_version_available">Newer version of app is available. Click to download.</string>
+    <string name="authorization_code_example">Ex: http://127.0.0.1:53682/?code=4/0BX2XfWi1VC9Iadsaa1hIX80rd17crGFCgyHgR_8rwkrIRJJf18LlSGbBWeg0wbZJdEZ3tm3A</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,11 +38,12 @@
     <string name="video">Video</string>
     <string name="sign_in">Sign in</string>
     <string name="enter_authorization_code">Enter authorization code?</string>
-    <string name="authorization_code">Authorization code</string>
+    <string name="authorization_url">Authorization url</string>
+    <string name="authorization_url_hint">Authorization url</string>
     <string name="submit">Submit</string>
-    <string name="please_enter_auth_code">Please enter authorization code</string>
+    <string name="please_enter_auth_url">Please enter authorization url</string>
     <string name="play_using">Play using</string>
     <string name="new_version_available">Newer version of app is available. Click to download.</string>
     <string name="authorization_code_example">Ex: http://127.0.0.1:53682/?code=4/0BX2XfWi1VC9Iadsaa1hIX80rd17crGFCgyHgR_8rwkrIRJJf18LlSGbBWeg0wbZJdEZ3tm3A</string>
-    <string name="important_note_message">Due to recent changes made by Google, it is no longer possible to direct to a page to directly copy authorization code.\n\nYou will need to copy the entire url from the browser address bar. This will page will not load and will show an error.\n\nPlease copy the entire url from the address bar and paste it in the dialog box.</string>
+    <string name="important_note_message">Due to recent changes made by Google, it is no longer possible to directly copy authorization code from the webpage after completion of OAuth Flow.\n\nYou will need to copy the entire url from the browser address bar. This page will not load and will show an error.\n\nPlease copy the entire url from the address bar and paste it in the dialog box.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,4 +44,5 @@
     <string name="play_using">Play using</string>
     <string name="new_version_available">Newer version of app is available. Click to download.</string>
     <string name="authorization_code_example">Ex: http://127.0.0.1:53682/?code=4/0BX2XfWi1VC9Iadsaa1hIX80rd17crGFCgyHgR_8rwkrIRJJf18LlSGbBWeg0wbZJdEZ3tm3A</string>
+    <string name="important_note_message">Due to recent changes made by Google, it is no longer possible to direct to a page to directly copy authorization code.\n\nYou will need to copy the entire url from the browser address bar. This will page will not load and will show an error.\n\nPlease copy the entire url from the address bar and paste it in the dialog box.</string>
 </resources>


### PR DESCRIPTION
This PR fixes the login issue created by recent [changes](https://developers.google.com/identity/protocols/oauth2/resources/oob-migration#:~:text=October%203%2C%202022%20%2D%20the%20OOB%20flow%20is%20deprecated%20for%20OAuth%20clients%20created%20before%20February%2028%2C%202022) made by Google in OAuth Flow.

It is not longer possible to use `urn:ietf:wg:oauth:2.0:oob` as redirect url and redirect to a page to copy auth-code.
https://github.com/itszechs/DriveStream/blob/5bc57aedb105ed38785f47b3ec0076250213ad0a/app/src/main/java/zechs/drive/stream/utils/util/Constants.kt#L15

The new changes requires apps to create a local server and listen on a local port and catch authorization code, which is possible on android but not very ideal in my opinion (maybe in future), so for the time being we just ask users for the entire auth-url and extract the auth-code ourselves fixing the login problem.

Closes #63  